### PR TITLE
Change order of adding bills

### DIFF
--- a/client/src/store/reducers.js
+++ b/client/src/store/reducers.js
@@ -142,9 +142,8 @@ const bills = (state = {}, action) => {
       return { ...state }
 
     case RECEIVE_ADD_BILL:
-      state[action.bill._id] = action.bill
       action.bill.id = action.bill._id
-      return { ...state }
+      return { [action.bill.id]:action.bill, ...state }
     default:
       return state
   }

--- a/client/src/store/reducers.js
+++ b/client/src/store/reducers.js
@@ -143,7 +143,7 @@ const bills = (state = {}, action) => {
 
     case RECEIVE_ADD_BILL:
       action.bill.id = action.bill._id
-      return { [action.bill.id]:action.bill, ...state }
+      return { [action.bill.id]: action.bill, ...state }
     default:
       return state
   }


### PR DESCRIPTION
## Motivation
Previously added bill was added at the end of the list which led to lack of visual impact after adding bill. Also, the position was incorrect bc they should be sorted by date.

## Changes
Assuming that the new bill is the newest when it comes to the date of adding, I changed the mechanism of appending bills. I dropped assigning in favor of destructuration. In the new approach, objects are being added as the first key, not the last one.